### PR TITLE
Fix GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
-        with:
-          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: .

--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 This repository hosts a small static site for experimenting with HTML, CSS and JavaScript. The site is automatically deployed to **GitHub Pages** using a workflow in `.github/workflows/pages.yml`.
 
+If this is the first time you enable Pages for the repository, make sure to manually enable the Pages site in the repository settings. Once enabled, subsequent deployments will be handled by the workflow.
+
 To view the site locally, simply open `index.html` in your browser.


### PR DESCRIPTION
## Summary
- remove `enablement: true` from Pages workflow to avoid permission error
- document that GitHub Pages must be enabled manually

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842110664bc8332916db2153a8d45ea